### PR TITLE
Fix typo in error message

### DIFF
--- a/client/gatt.c
+++ b/client/gatt.c
@@ -657,7 +657,7 @@ static int parse_offset(const char *arg)
 
 	offset = strtoul(arg, &endptr, 0);
 	if (!endptr || *endptr != '\0' || offset > UINT16_MAX) {
-		bt_shell_printf("Invalid offload: %s", arg);
+		bt_shell_printf("Invalid offset: %s", arg);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
It says "Invalid offload" while it should be "Invalid offset".